### PR TITLE
Add's author config and data entry for the warning

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -43,3 +43,8 @@
 .cdx-warning__title {
   margin-bottom: 6px;
 }
+
+.cdx-warning__author {
+  text-align: right;
+  color: #6c757d!important;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import ToolboxIcon from './svg/toolbox.svg';
  * @description Warning Tool`s input and output data
  * @property {string} title - warning`s title
  * @property {string} message - warning`s message
+ * @property {string} author - warning`s author
  *
  * @typedef {object} WarningConfig
  * @description Warning Tool`s initial configuration
@@ -77,6 +78,7 @@ export default class Warning {
       baseClass: this.api.styles.block,
       wrapper: 'cdx-warning',
       title: 'cdx-warning__title',
+      author: 'cdx-warning__author',
       input: this.api.styles.input,
       message: 'cdx-warning__message'
     };
@@ -97,7 +99,8 @@ export default class Warning {
 
     this.data = {
       title: data.title || '',
-      message: data.message || ''
+      message: data.message || '',
+      author: data.author || config.author || ''
     };
   }
 
@@ -117,11 +120,19 @@ export default class Warning {
       innerHTML: this.data.message
     });
 
+
     title.dataset.placeholder = this.titlePlaceholder;
     message.dataset.placeholder = this.messagePlaceholder;
 
     container.appendChild(title);
     container.appendChild(message);
+    if (this.data.author) {
+      const author = this._make('div', [this.CSS.author], {
+        contentEditable: false,
+        innerHTML: this.data.author
+      })
+      container.appendChild(author);
+    }
 
     return container;
   }
@@ -138,7 +149,8 @@ export default class Warning {
 
     return Object.assign(this.data, {
       title: title.innerHTML,
-      message: message.innerHTML
+      message: message.innerHTML,
+      author: this.data.author || this.config.author
     });
   }
 
@@ -173,8 +185,8 @@ export default class Warning {
    static get sanitize() {
       return {
           title: {},
-          message: {}
+          message: {},
+          author: {}
       };
   }
 }
-


### PR DESCRIPTION
Allow saving the author of the warning in the event that editorjs is
being used by more than one user.

For example when creating an article for a newspaper, the news item
will be reviewed several times by proofreaders, editors and designers,
in each step each role can add warnings in the body of the document.