### PR TITLE
Adjust Line Break Policy and Add Shift+Enter Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# egg- Fork Version
+
+Changed line break policy
+
 ![](https://badgen.net/badge/CodeX%20Editor/v2.0/blue)
 
 # Warning Tool

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@editorjs/warning",
-  "version": "1.4.0",
+  "name": "@egg-/editorjs-warning",
+  "version": "1.4.1",
   "keywords": [
     "codex editor",
     "warning",

--- a/src/index.css
+++ b/src/index.css
@@ -28,19 +28,13 @@
 
 .cdx-warning::before {
   content: '';
-  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='5' y='5' width='14' height='14' rx='4' stroke='black' stroke-width='2'/%3E%3Cline x1='12' y1='9' x2='12' y2='12' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M12 15.02V15.01' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3QgeD0iNC43NSIgeT0iNC43NSIgd2lkdGg9IjE0LjUiIGhlaWdodD0iMTQuNSIgcng9IjcuMjUiIHN0cm9rZT0iIzNEM0QzRCIgc3Ryb2tlLXdpZHRoPSIxLjUiLz4KPHBhdGggZD0iTTEyLjg0OTcgMTMuMTY4NUwxMi45NzU2IDguMDAwMDdDMTIuOTg5IDcuNDUxNzMgMTIuNTQ4MSA3IDExLjk5OTYgN0MxMS40NTE0IDcgMTEuMDEwNyA3LjQ1MTI4IDExLjAyMzYgNy45OTkzNUwxMS4xNDU3IDEzLjE2NzlDMTEuMTU2NiAxMy42MzA2IDExLjUzNDkgMTQgMTEuOTk3NyAxNEMxMi40NjAzIDE0IDEyLjgzODQgMTMuNjMxIDEyLjg0OTcgMTMuMTY4NVoiIGZpbGw9IiMzRDNEM0QiLz4KPGNpcmNsZSBjeD0iMTIiIGN5PSIxNiIgcj0iMSIgZmlsbD0iIzNEM0QzRCIvPgo8cmVjdCB4PSI0Ljc1IiB5PSI0Ljc1IiB3aWR0aD0iMTQuNSIgaGVpZ2h0PSIxNC41IiByeD0iNy4yNSIgc3Ryb2tlPSIjM0QzRDNEIiBzdHJva2Utd2lkdGg9IjEuNSIvPgo8cGF0aCBkPSJNMTIuODQ5NyAxMy4xNjg1TDEyLjk3NTYgOC4wMDAwN0MxMi45ODkgNy40NTE3MyAxMi41NDgxIDcgMTEuOTk5NiA3QzExLjQ1MTQgNyAxMS4wMTA3IDcuNDUxMjggMTEuMDIzNiA3Ljk5OTM1TDExLjE0NTcgMTMuMTY3OUMxMS4xNTY2IDEzLjYzMDYgMTEuNTM0OSAxNCAxMS45OTc3IDE0QzEyLjQ2MDMgMTQgMTIuODM4NCAxMy42MzEgMTIuODQ5NyAxMy4xNjg1WiIgZmlsbD0iIzNEM0QzRCIvPgo8Y2lyY2xlIGN4PSIxMiIgY3k9IjE2IiByPSIxIiBmaWxsPSIjM0QzRDNEIi8+Cjwvc3ZnPgo=");
   width: 24px;
   height: 24px;
   background-size: 24px 24px;
   position: absolute;
   margin-top: 8px;
   left: 0;
-}
-
-@media all and (max-width: 735px) {
-  .cdx-warning::before {
-    display: none;
-  }
 }
 
 .cdx-warning__message {

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export default class Warning {
    * @returns {boolean}
    */
   static get enableLineBreaks() {
-    return true;
+    return false;
   }
 
   /**
@@ -185,7 +185,9 @@ export default class Warning {
   static get sanitize() {
     return {
       title: {},
-      message: {},
+      message: {
+        br: true,
+      },
     };
   }
 }


### PR DESCRIPTION
### Changes Made:

1. Adjusted the settings to disallow the preservation of line breaks. Line breaks are no longer permitted, following a similar policy to Notion's callout feature.
2. Implemented functionality to allow users to add line breaks using the Shift+Enter combination.

### Reasons for Changes:

The previous line break policy could lead to unexpected confusion among users. By adopting a policy similar to Notion's callout feature, users will experience a more consistent editing environment. Additionally, the implementation of Shift+Enter functionality provides users with the flexibility to add line breaks only when necessary.

### Before Changes:

- Line breaks were preserved within text, potentially resulting in discrepancies between the edited and rendered content.

### After Changes:

- A policy similar to Notion's callout feature has been adopted, ensuring a more consistent user experience.
- Users can utilize Shift+Enter to add line breaks as needed.

### Additional Information:

These changes aim to enhance user convenience and provide a more consistent editing environment. We anticipate that these modifications will have a positive impact on user experience.
